### PR TITLE
fixed vector import issues for deriving Unbox.

### DIFF
--- a/netpbm.cabal
+++ b/netpbm.cabal
@@ -1,5 +1,5 @@
 name:          netpbm
-version:       1.0.0
+version:       1.0.1
 license:       MIT
 copyright:     2013 Niklas Hambüchen <mail@nh2.me>
 author:        Niklas Hambüchen <mail@nh2.me>
@@ -20,6 +20,10 @@ description:
   The current implementation parses PPM images at around 10 MB/s on a Core i5-2520M.
   .
   CHANGELOG
+  .
+  Version 1.0.1
+  .
+  * Added required Vector imports necessary for deriving Unbox instances.
   .
   Version 1.0.0
   .

--- a/src/Graphics/Netpbm.hs
+++ b/src/Graphics/Netpbm.hs
@@ -43,6 +43,9 @@ import qualified Data.Vector.Storable as S
 import           Data.Vector.Storable ((!))
 import qualified Data.Vector.Storable.Mutable as SM
 
+import qualified Data.Vector.Generic
+import qualified Data.Vector.Generic.Mutable
+
 import Data.Vector.Unboxed.Deriving
 
 


### PR DESCRIPTION
Not sure if it was vector package or vector-th-unbox, but something broke derivingUnbox. Here is the fix for it.
PS. Are you planning on adding PBM image types write functionality?
